### PR TITLE
Fix two "reply" buttons showing on a screen between 768 and 991 px

### DIFF
--- a/http/template/user/message/replyable.html
+++ b/http/template/user/message/replyable.html
@@ -63,7 +63,7 @@
         </div>
         <% } %>
         <span class="nodecor js-expand js-readmore row nomargin">
-            <div class="visible-xs visible-sm btn btn-white btn-block botspace">
+            <div class="visible-xs btn btn-white btn-block botspace">
                 Read more and reply >>
             </div>
         </span>


### PR DESCRIPTION
My first contribution to this website !

Starting small but useful:

The large ("btn-block") reply button had both "visible-xs" and "visible-sm" properties, meaning two reply buttons would show  on a screen between 768 and 991 px.

Only the first property was needed.